### PR TITLE
Add check to ensure parent has the same phantom-ness as child. …

### DIFF
--- a/lib/syntax_tree.ml
+++ b/lib/syntax_tree.ml
@@ -25,6 +25,14 @@ type linkage =
   | Linkage_private
   | Linkage_phantom
 
+let linkage_to_string(l: linkage): string
+  =
+  match l with
+  | Linkage_extern -> "extern"
+  | Linkage_public -> "public"
+  | Linkage_private -> "private"
+  | Linkage_phantom -> "phantom"
+
 type definition =
   | Definition_given
   | Definition_expr of definition_expr


### PR DESCRIPTION
…Changing getters.opti variable d to non-phantom e.g. private silently fails

TESTING: confirmed it fails now, passes existing tests, other generated c is equivalent